### PR TITLE
Fix default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "pino-pretty": "^4.3.0",
     "tsdx": "^0.14.1",
     "tslib": "^2.0.3",
-    "typedoc": "0.17.0-3",
+    "typedoc": "0.19.0",
     "typedoc-plugin-markdown": "^3.0.11",
     "typescript": "^4.0.3"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export interface Options {
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing
-export default fastifyPlugin(serverTimingPlugin, { name: 'server-timing', fastify: '3.x' });
+export default fastifyPlugin(serverTimingPlugin, { name: 'server-timing', fastify: '3.x' })
 
 function serverTimingPlugin(
   fastify: FastifyInstance,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import { FastifyInstance, FastifyPluginCallback, FastifyRequest, FastifyReply } from 'fastify'
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 
 import fastifyPlugin from 'fastify-plugin'
 
-const { never } = require('@carv/stdlib')
+import { never } from '@carv/stdlib'
 
 const kServerTimings = Symbol('fastify-server-timing')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
+import { FastifyInstance, FastifyPluginCallback, FastifyRequest, FastifyReply } from 'fastify'
 
-const fp = require('fastify-plugin')
+import fastifyPlugin from 'fastify-plugin'
 
 const { never } = require('@carv/stdlib')
 
@@ -78,7 +78,7 @@ export interface Options {
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing
-export default fp(serverTimingPlugin, { name: 'server-timing', fastify: '3.x' })
+export default fastifyPlugin(serverTimingPlugin, { name: 'server-timing', fastify: '3.x' });
 
 function serverTimingPlugin(
   fastify: FastifyInstance,


### PR DESCRIPTION
This PR fixes `any`  default export with `FastifyPluginCallback<Options>` strict type
Also I had to bump one dependency